### PR TITLE
Fix publishing to nuget.org

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
       run: |
         echo 'Creating Release ${{ env.GitVersion_SemVer }}'
         gh release create '${{ env.GitVersion_SemVer }}' ./nuget/* --target '${{ github.sha }}' --generate-notes
-        dotnet nuget push "*.nupkg" --api-key $env:NUGET_API_KEY --source https://api.nuget.org/v3/index.json
+        dotnet nuget push "nuget/*.nupkg" --api-key $env:NUGET_API_KEY --source https://api.nuget.org/v3/index.json
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Currently the CI build via GitHub Actions fails while trying to publish the created NuGet packages to nuget.org (see [this build](https://github.com/package-url/packageurl-dotnet/runs/5345506890?check_suite_focus=true)).

That's because the `dotnet nuget push` command does not include the subfolder in which the nuget packages are located.