### PR TITLE
Change package ID to "packageurl-dotnet"

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ Installation
 -------------------
 
 ```sh
-dotnet add <Path-to-Project-file> package PackageUrl
+dotnet add <Path-to-Project-file> package packageurl-dotnet
 ```
 
 or in project file, add:
 
 ```xml
-<PackageReference Include="PackageUrl" Version="1.0.0" />
+<PackageReference Include="packageurl-dotnet" Version="1.0.0" />
 ```
 
 Usage

--- a/src/PackageUrl.csproj
+++ b/src/PackageUrl.csproj
@@ -6,6 +6,7 @@
       Package
       https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#pack-target
     -->
+    <PackageId>packageurl-dotnet</PackageId>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>        
     <PackageTags>Package URL;purl</PackageTags>
     <PackageDescription>.NET implementation of the package url spec</PackageDescription>

--- a/tests/packages.lock.json
+++ b/tests/packages.lock.json
@@ -1037,7 +1037,7 @@
           "xunit.extensibility.core": "[2.4.1]"
         }
       },
-      "packageurl": {
+      "packageurl-dotnet": {
         "type": "Project"
       }
     }


### PR DESCRIPTION
Fixes the issue with an existing package ID from an unofficial package as described in #12.

Upload tested locally with our existing NuGet API Key:

```shell
dotnet nuget push "nuget/*.nupkg" --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json
Pushing packageurl-dotnet.0.1.8-test-upload.0.nupkg to 'https://www.nuget.org/api/v2/package'...
  PUT https://www.nuget.org/api/v2/package/
  Created https://www.nuget.org/api/v2/package/ 1017ms
Your package was pushed.
Pushing packageurl-dotnet.0.1.8-test-upload.0.snupkg to 'https://www.nuget.org/api/v2/symbolpackage'...
  PUT https://www.nuget.org/api/v2/symbolpackage/
  Created https://www.nuget.org/api/v2/symbolpackage/ 503ms
Your package was pushed.
```

And here's the result:

![image](https://user-images.githubusercontent.com/38790465/155884548-c6b1edf2-1331-4d61-9c31-1a4af4b73ac2.png)

https://www.nuget.org/packages/packageurl-dotnet/