### PR TITLE
Fix URL of NuGet Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Build](https://github.com/package-url/packageurl-dotnet/actions/workflows/build.yml/badge.svg)
 [![License][license-image]][license-url]
-[![NuGet version (packageurl-dotnet)](https://img.shields.io/nuget/v/packageurl.svg?style=flat-square)](https://www.nuget.org/packages/packageurl-dotnet/)
+[![NuGet version (packageurl-dotnet)](https://img.shields.io/nuget/v/packageurl-dotnet)](https://www.nuget.org/packages/packageurl-dotnet/)
 
 Package URL (purl) for .NET
 =========


### PR DESCRIPTION
The NuGet Badge was using the wrong URL (of the now unlisted un-official package) and is showing "package not found":

![image](https://user-images.githubusercontent.com/38790465/156004441-54123732-1a27-42ce-982c-844aaa62c83a.png)

Now it's using the correct URL and the badge is working again:

![image](https://user-images.githubusercontent.com/38790465/156004593-00533728-d13f-4dc9-8d4b-0c9d02b6c59c.png)
