### PR TITLE
Added support to serialize and de-serialize PackageURLs to and from json

### DIFF
--- a/src/PackageUrl.cs
+++ b/src/PackageUrl.cs
@@ -23,6 +23,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
+using Newtonsoft.Json;
 
 namespace PackageUrl
 {
@@ -111,6 +112,7 @@ namespace PackageUrl
         /// @param qualifiers an array of key/value pair qualifiers
         /// @param subpath the subpath string
         /// <exception cref="MalformedPackageUrlException">Thrown when parsing fails.</exception>
+        [JsonConstructor]
         public PackageURL(string type, string @namespace, string name, string version, SortedDictionary<string, string> qualifiers, string subpath)
         {
             Type = ValidateType(type);
@@ -165,6 +167,26 @@ namespace PackageUrl
             return purl.ToString();
         }
 
+        /// <summary>
+        /// Converts this <see cref="PackageUrl"/> to a json string.
+        /// </summary>
+        /// <returns>A json string representing this instance of <see cref="PackageUrl"/>.</returns>
+        public string ToJson()
+        {
+            return JsonConvert.SerializeObject(this);
+        }
+        
+        /// <summary>
+        /// Converts a json string into a <see cref="PackageURL"/>.
+        /// </summary>
+        /// <param name="json">The json string representing the <see cref="PackageURL"/>.</param>
+        /// <returns>A new <see cref="PackageURL"/> constructed from the json string.</returns>
+        /// <exception cref="InvalidCastException">If the json string cannot be deserialized into a <see cref="PackageURL"/>.</exception>
+        public static PackageURL FromJson(string json)
+        {
+            return JsonConvert.DeserializeObject<PackageURL>(json) ?? throw new InvalidCastException();
+        }
+        
         private void Parse(string purl)
         {
             if (purl == null || string.IsNullOrWhiteSpace(purl))

--- a/src/PackageUrl.cs
+++ b/src/PackageUrl.cs
@@ -23,7 +23,8 @@ using System.Collections.Generic;
 using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
-using Newtonsoft.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace PackageUrl
 {
@@ -173,7 +174,7 @@ namespace PackageUrl
         /// <returns>A json string representing this instance of <see cref="PackageUrl"/>.</returns>
         public string ToJson()
         {
-            return JsonConvert.SerializeObject(this);
+            return JsonSerializer.Serialize(this);
         }
         
         /// <summary>
@@ -184,7 +185,14 @@ namespace PackageUrl
         /// <exception cref="InvalidCastException">If the json string cannot be deserialized into a <see cref="PackageURL"/>.</exception>
         public static PackageURL FromJson(string json)
         {
-            return JsonConvert.DeserializeObject<PackageURL>(json) ?? throw new InvalidCastException();
+            try
+            {
+                return JsonSerializer.Deserialize<PackageURL>(json) ?? throw new JsonException("The deserialized PackageURL was null.");
+            }
+            catch (Exception e)
+            {
+                throw new InvalidCastException($"Wasn't able to deserialize: {json}",e);
+            }
         }
         
         private void Parse(string purl)

--- a/src/PackageUrl.csproj
+++ b/src/PackageUrl.csproj
@@ -13,4 +13,8 @@
     <PackageOutputPath>../nuget</PackageOutputPath>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+
 </Project>

--- a/src/PackageUrl.csproj
+++ b/src/PackageUrl.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="System.Text.Json" Version="6.0.2" />
   </ItemGroup>
 
 </Project>

--- a/src/packages.lock.json
+++ b/src/packages.lock.json
@@ -27,11 +27,28 @@
           "Microsoft.NETCore.Platforms": "1.1.0"
         }
       },
-      "Newtonsoft.Json": {
+      "System.Text.Json": {
         "type": "Direct",
-        "requested": "[13.0.1, )",
-        "resolved": "13.0.1",
-        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+        "requested": "[6.0.2, )",
+        "resolved": "6.0.2",
+        "contentHash": "0nE2gwXLn3PTBOPwORLqwuYvWB+Beomt9ZBX+6LmogMNKUvfD1SoDb/ycB1vBntT94rGaB/SvxEyeLu14H6aEg==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.4",
+          "System.Numerics.Vectors": "4.5.0",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.Encodings.Web": "6.0.0",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
       },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
@@ -47,6 +64,49 @@
         "type": "Transitive",
         "resolved": "1.1.1",
         "contentHash": "WMcGpWKrmJmzrNeuaEb23bEMnbtR/vLmvZtkAP5qWu7vQsY59GqfRJd65sFpBszbd2k/bQ8cs8eWawQKAabkVg=="
+      },
+      "System.Buffers": {
+        "type": "Transitive",
+        "resolved": "4.5.1",
+        "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
+      },
+      "System.Memory": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "1MbJTHS1lZ4bS4FmsJjnuGJOu88ZzTT2rLvrhW7Ygic+pC0NWA+3hgAen0HRdsocuQXCkUTdFn9yHJJhsijDXw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Numerics.Vectors": "4.4.0",
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+        }
+      },
+      "System.Numerics.Vectors": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "QQTlPTl06J/iiDbJCiepZ4H//BVraReU4O4EoRw1U02H5TLUIT7xn3GnDp9AXPSlJUDyFs4uWjWafNX6WrAojQ=="
+      },
+      "System.Runtime.CompilerServices.Unsafe": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "Vg8eB5Tawm1IFqj4TVK1czJX89rhFxJo9ELqc/Eiq0eXy13RK00eubyU6TJE6y+GQXjyV5gSfiewDUZjQgSE0w==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.4",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+        }
       }
     }
   }

--- a/src/packages.lock.json
+++ b/src/packages.lock.json
@@ -27,6 +27,12 @@
           "Microsoft.NETCore.Platforms": "1.1.0"
         }
       },
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "requested": "[13.0.1, )",
+        "resolved": "13.0.1",
+        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+      },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
         "resolved": "1.1.1",

--- a/tests/PackageUrl.Tests.cs
+++ b/tests/PackageUrl.Tests.cs
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using Newtonsoft.Json;
 using PackageUrl.Tests.TestAssets;
 using Xunit;
 
@@ -78,6 +79,40 @@ namespace PackageUrl.Tests
             if (data.Qualifiers != null)
             {
                 Assert.NotNull(purl.Qualifiers);
+            }
+        }
+        
+        [Theory]
+        [InlineData("{\"Scheme\":\"pkg\",\"Type\":\"npm\",\"Namespace\":null,\"Name\":\"foo\"," +
+                    "\"Version\":\"1.2.3\",\"Qualifiers\":null,\"Subpath\":null}",
+            "pkg:npm/foo@1.2.3")]
+        public void TestJsonSerialization(string serializedPurl, string packageUrlStr)
+        {
+            PackageURL purl = new PackageURL(packageUrlStr);
+            string jsonPurl = purl.ToJson();
+
+            Assert.Equal(serializedPurl, jsonPurl);
+        }
+        
+        [Theory]
+        [InlineData("{\"Scheme\":\"pkg\",\"Type\":\"npm\",\"Namespace\":null,\"Name\":\"foo\"," +
+                    "\"Version\":\"1.2.3\",\"Qualifiers\":null,\"Subpath\":null}",
+            "pkg:npm/foo@1.2.3")]
+        public void TestJsonDeserialization(string data, string packageUrlStr)
+        {
+            PackageURL expectedPurl = new PackageURL(packageUrlStr);
+            PackageURL deserializedPurl = PackageURL.FromJson(data);
+
+            Assert.Equal(expectedPurl.ToString(), deserializedPurl.ToString());
+            Assert.Equal("pkg", deserializedPurl.Scheme);
+            Assert.Equal(expectedPurl.Type, deserializedPurl.Type);
+            Assert.Equal(expectedPurl.Namespace, deserializedPurl.Namespace);
+            Assert.Equal(expectedPurl.Name, deserializedPurl.Name);
+            Assert.Equal(expectedPurl.Version, deserializedPurl.Version);
+            Assert.Equal(expectedPurl.Subpath, deserializedPurl.Subpath);
+            if (expectedPurl.Qualifiers != null)
+            {
+                Assert.NotNull(deserializedPurl.Qualifiers);
             }
         }
     }

--- a/tests/PackageUrl.Tests.cs
+++ b/tests/PackageUrl.Tests.cs
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using Newtonsoft.Json;
+using System;
 using PackageUrl.Tests.TestAssets;
 using Xunit;
 
@@ -114,6 +114,13 @@ namespace PackageUrl.Tests
             {
                 Assert.NotNull(deserializedPurl.Qualifiers);
             }
+        }
+        
+        [Theory]
+        [InlineData("\"Type\":\"npm\",\"Name\":\"foo\",\"Version\":\"1.2.3\"}")]
+        public void TestInvalidJsonDeserialization(string data)
+        {
+            Assert.Throws<InvalidCastException>(() => PackageURL.FromJson(data));
         }
     }
 }

--- a/tests/packages.lock.json
+++ b/tests/packages.lock.json
@@ -1038,7 +1038,10 @@
         }
       },
       "packageurl-dotnet": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.1"
+        }
       }
     }
   }

--- a/tests/packages.lock.json
+++ b/tests/packages.lock.json
@@ -681,6 +681,11 @@
           "Microsoft.NETCore.Targets": "1.1.0"
         }
       },
+      "System.Runtime.CompilerServices.Unsafe": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+      },
       "System.Runtime.Extensions": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -904,6 +909,23 @@
           "System.Text.Encoding": "4.3.0"
         }
       },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "Vg8eB5Tawm1IFqj4TVK1czJX89rhFxJo9ELqc/Eiq0eXy13RK00eubyU6TJE6y+GQXjyV5gSfiewDUZjQgSE0w==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Text.Json": {
+        "type": "Transitive",
+        "resolved": "6.0.2",
+        "contentHash": "0nE2gwXLn3PTBOPwORLqwuYvWB+Beomt9ZBX+6LmogMNKUvfD1SoDb/ycB1vBntT94rGaB/SvxEyeLu14H6aEg==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.Encodings.Web": "6.0.0"
+        }
+      },
       "System.Text.RegularExpressions": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1040,7 +1062,7 @@
       "packageurl-dotnet": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "13.0.1"
+          "System.Text.Json": "6.0.2"
         }
       }
     }


### PR DESCRIPTION
Currently, there is no support for converting PackageURLs to json, or converting a json representation of a PackageURL back to the object. This PR aims to add that support. It also provides 2 unit tests, one for serialization and one for de-serialization.

Please let me know if you have any questions or comments!