### PR TITLE
cocoapods, cran, vsm and cpan packages should not be lowered

### DIFF
--- a/src/PackageUrl.cs
+++ b/src/PackageUrl.cs
@@ -261,30 +261,26 @@ namespace PackageUrl
             {
                 return null;
             }
-            if (Type == "vsm" || Type == "cran")
+            return Type switch
             {
-                return WebUtility.UrlDecode(@namespace);
+                "vsm" or "cran" => WebUtility.UrlDecode(@namespace);
+                _ => WebUtility.UrlDecode(@namespace.ToLower());
             }
-            return WebUtility.UrlDecode(@namespace.ToLower());
         }
 
         private string ValidateName(string name)
         {
+
             if (name == null)
             {
-                throw new MalformedPackageUrlException("The PackageURL name specified is invalid");
+                return null;
             }
-            // These repositorys are case sensitive and require the original casing.
-            if (Type == "nuget" || Type == "cocoapods" || Type == "cpan" || Type == "vsm" || Type == "cran")
+            return Type switch
             {
-                return name;
-            }
-            if (Type == "pypi")
-            {
-                name = name.Replace('_', '-');
-            }
-            
-            return name.ToLower();
+                "nuget" or "cocoapods" or "cpan" or "vsm" or "cran" => name,
+                "pypi" => name.Replace('_', '-').ToLower(),
+                _ => name.ToLower()
+            };
         }
 
         private static SortedDictionary<string, string> ValidateQualifiers(string qualifiers)

--- a/src/PackageUrl.cs
+++ b/src/PackageUrl.cs
@@ -261,11 +261,7 @@ namespace PackageUrl
             {
                 return null;
             }
-            return Type switch
-            {
-                "vsm" or "cran" => WebUtility.UrlDecode(@namespace),
-                _ => WebUtility.UrlDecode(@namespace.ToLower())
-            };
+            return WebUtility.UrlDecode(@namespace);
         }
 
         private string ValidateName(string name)
@@ -275,12 +271,7 @@ namespace PackageUrl
             {
                 return null;
             }
-            return Type switch
-            {
-                "nuget" or "cocoapods" or "cpan" or "vsm" or "cran" => name,
-                "pypi" => name.Replace('_', '-').ToLower(),
-                _ => name.ToLower()
-            };
+            return name;
         }
 
         private static SortedDictionary<string, string> ValidateQualifiers(string qualifiers)

--- a/src/PackageUrl.cs
+++ b/src/PackageUrl.cs
@@ -270,20 +270,16 @@ namespace PackageUrl
             {
                 throw new MalformedPackageUrlException("The PackageURL name specified is invalid");
             }
+            // These repositorys are case sensitive and require the original casing.
+            if (Type == "nuget" || Type == "cocoapods" || Type == "cpan" || Type == "vsm" || Type == "cran")
+            {
+                return name;
+            }
             if (Type == "pypi")
             {
                 name = name.Replace('_', '-');
             }
-            if (Type == "nuget")
-            {
-                return name;
-            }
-            // These repositorys are case sensitive and require the original casing.
-            // For example, the package location for cocoapods is determined by the first 3 bytes of an MD5 of the case sensitive name
-            if (Type == "cocoapods" || Type == "cpan" || Type == "vsm" || Type == "cran")
-            {
-                return name;
-            }
+            
             return name.ToLower();
         }
 

--- a/src/PackageUrl.cs
+++ b/src/PackageUrl.cs
@@ -270,7 +270,6 @@ namespace PackageUrl
 
         private string ValidateName(string name)
         {
-
             if (name == null)
             {
                 return null;

--- a/src/PackageUrl.cs
+++ b/src/PackageUrl.cs
@@ -272,7 +272,7 @@ namespace PackageUrl
         {
             if (name == null)
             {
-                return null;
+                throw new MalformedPackageUrlException("The PackageURL name specified is invalid");
             }
             return Type switch
             {

--- a/src/PackageUrl.cs
+++ b/src/PackageUrl.cs
@@ -263,8 +263,8 @@ namespace PackageUrl
             }
             return Type switch
             {
-                "vsm" or "cran" => WebUtility.UrlDecode(@namespace);
-                _ => WebUtility.UrlDecode(@namespace.ToLower());
+                "vsm" or "cran" => WebUtility.UrlDecode(@namespace),
+                _ => WebUtility.UrlDecode(@namespace.ToLower())
             }
         }
 

--- a/src/PackageUrl.cs
+++ b/src/PackageUrl.cs
@@ -265,7 +265,7 @@ namespace PackageUrl
             {
                 "vsm" or "cran" => WebUtility.UrlDecode(@namespace),
                 _ => WebUtility.UrlDecode(@namespace.ToLower())
-            }
+            };
         }
 
         private string ValidateName(string name)

--- a/src/PackageUrl.cs
+++ b/src/PackageUrl.cs
@@ -255,7 +255,7 @@ namespace PackageUrl
             return type.ToLower();
         }
 
-        private static string ValidateNamespace(string @namespace)
+        private string ValidateNamespace(string @namespace)
         {
             if (@namespace == null)
             {

--- a/src/PackageUrl.cs
+++ b/src/PackageUrl.cs
@@ -261,7 +261,11 @@ namespace PackageUrl
             {
                 return null;
             }
-            return WebUtility.UrlDecode(@namespace);
+            return Type switch
+            {
+                "vsm" or "cran" => WebUtility.UrlDecode(@namespace),
+                _ => WebUtility.UrlDecode(@namespace.ToLower())
+            };
         }
 
         private string ValidateName(string name)
@@ -271,7 +275,12 @@ namespace PackageUrl
             {
                 return null;
             }
-            return name;
+            return Type switch
+            {
+                "nuget" or "cocoapods" or "cpan" or "vsm" or "cran" => name,
+                "pypi" => name.Replace('_', '-').ToLower(),
+                _ => name.ToLower()
+            };
         }
 
         private static SortedDictionary<string, string> ValidateQualifiers(string qualifiers)

--- a/src/PackageUrl.cs
+++ b/src/PackageUrl.cs
@@ -261,6 +261,10 @@ namespace PackageUrl
             {
                 return null;
             }
+            if (Type == "vsm" || Type == "cran")
+            {
+                return WebUtility.UrlDecode(@namespace);
+            }
             return WebUtility.UrlDecode(@namespace.ToLower());
         }
 

--- a/src/PackageUrl.cs
+++ b/src/PackageUrl.cs
@@ -278,6 +278,12 @@ namespace PackageUrl
             {
                 return name;
             }
+            // These repositorys are case sensitive and require the original casing.
+            // For example, the package location for cocoapods is determined by the first 3 bytes of an MD5 of the case sensitive name
+            if (Type == "cocoapods" || Type == "cpan" || Type == "vsm" || Type == "cran")
+            {
+                return name;
+            }
             return name.ToLower();
         }
 

--- a/tests/TestAssets/test-suite-data.json
+++ b/tests/TestAssets/test-suite-data.json
@@ -277,5 +277,65 @@
     "qualifiers": null,
     "subpath": null,
     "is_invalid": false
+  },
+  {
+    "description": "cocoapods names are case sensitive",
+    "purl": "pkg:cocoapods/MapsIndoors@3.24.0",
+    "canonical_purl": "pkg:cocoapods/MapsIndoors@3.24.0",
+    "type": "cocoapods",
+    "namespace": null,
+    "name": "MapsIndoors",
+    "version": "3.24.0",
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
+  },
+  {
+    "description": "cpan names are case sensitive",
+    "purl": "pkg:cpan/Perl-Version@1.013",
+    "canonical_purl": "pkg:cpan/Perl-Version@1.013",
+    "type": "cpan",
+    "namespace": null,
+    "name": "Perl-Version",
+    "version": "1.013",
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
+  },
+  {
+    "description": "cran names are case sensitive",
+    "purl": "pkg:cran/MixTwice@2.0",
+    "canonical_purl": "pkg:cran/MixTwice@2.0",
+    "type": "cran",
+    "namespace": null,
+    "name": "MixTwice",
+    "version": "2.0",
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
+  },
+  {
+    "description": "Visual Studio Marketplace namespaces are case sensitive",
+    "purl": "pkg:vsm/MS-CST-E/vscode-devskim@0.6.8",
+    "canonical_purl": "pkg:vsm/MS-CST-E/vscode-devskim@0.6.8",
+    "type": "vsm",
+    "namespace": "MS-CST-E",
+    "name": "vscode-devskim",
+    "version": "0.6.8",
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
+  },
+  {
+    "description": "Visual Studio Marketplace names are case sensitive",
+    "purl": "pkg:vsm/ritwickdey/LiveServer@5.7.4",
+    "canonical_purl": "pkg:vsm/ritwickdey/LiveServer@5.7.4",
+    "type": "vsm",
+    "namespace": "ritwickdey",
+    "name": "LiveServer",
+    "version": "5.7.4",
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
   }
 ]


### PR DESCRIPTION
Like nuget, these other repos are case sensitive.  Additionally the namespaces for some of them are case sensitive.

Cocoapods, for example stores the pod specs on their GitHub based on the first 3 bytes of an MD5 of the package name.

So `RandomKit` => `8278d1b7c80616d5bbcbe1261075786c` => `827` yields the location of the podspec:

https://github.com/CocoaPods/Specs/tree/master/Specs/8/2/7/RandomKit

But currently the name is automatically lowered: `randomkit` => `8d6a963d5a8e769c65f0bf1f867f6d02` => `8d6` which is not the correct location.

https://github.com/CocoaPods/Specs/tree/master/Specs/8/d/6/randomkit => 404