### PR TITLE
npm package names should not be lowered

### DIFF
--- a/src/PackageUrl.cs
+++ b/src/PackageUrl.cs
@@ -276,7 +276,7 @@ namespace PackageUrl
             }
             return Type switch
             {
-                "nuget" or "cocoapods" or "cpan" or "vsm" or "cran" => name,
+                "nuget" or "cocoapods" or "cpan" or "vsm" or "cran" or "npm" => name,
                 "pypi" => name.Replace('_', '-').ToLower(),
                 _ => name.ToLower()
             };

--- a/tests/TestAssets/test-suite-data.json
+++ b/tests/TestAssets/test-suite-data.json
@@ -168,6 +168,18 @@
     "is_invalid": false
   },
   {
+    "description": "npm names are case sensitive (npm only requires lowercase names for new packages)",
+    "purl": "pkg:npm/Acid@3.0.17",
+    "canonical_purl": "pkg:npm/Acid@3.0.17",
+    "type": "npm",
+    "namespace": null,
+    "name": "Acid",
+    "version": "3.0.17",
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
+  },
+  {
     "description": "nuget names are case sensitive",
     "purl": "pkg:Nuget/EnterpriseLibrary.Common@6.0.1304",
     "canonical_purl": "pkg:nuget/EnterpriseLibrary.Common@6.0.1304",


### PR DESCRIPTION
Like a few other package managers, npm package names are case sensitive. They now disallow uppercase characters in names for new packages (as [discussed here](https://blog.npmjs.org/post/168978377570/new-package-moniker-rules.html)), but older packages having uppercase names still exist (see https://www.npmjs.com/package/Acid vs. https://www.npmjs.com/package/acid).

So far I haven't seen evidence that scopes having uppercase characters exist, so I left that as-is.