### PR TITLE
Fix issues handling golang packages with multi-part namespaces.

### DIFF
--- a/src/PackageUrl.cs
+++ b/src/PackageUrl.cs
@@ -140,8 +140,8 @@ namespace PackageUrl
             purl.Append('/');
             if (Namespace != null)
             {
-                purl.Append(WebUtility.UrlEncode(Namespace));
-                purl.Replace(EncodedSlash, "/");
+                string encodedNamespace = WebUtility.UrlEncode(Namespace).Replace(EncodedSlash, "/");
+                purl.Append(encodedNamespace);
                 purl.Append('/');
             }
             if (Name != null)

--- a/src/PackageUrl.cs
+++ b/src/PackageUrl.cs
@@ -42,6 +42,11 @@ namespace PackageUrl
     [Serializable]
     public sealed class PackageURL
     {
+        /// <summary>
+        /// The url encoding of /.
+        /// </summary>
+        private const string EncodedSlash = "%2F";
+
         private static readonly Regex s_typePattern = new Regex("^[a-zA-Z][a-zA-Z0-9.+-]+$", RegexOptions.Compiled);
 
         /// <summary>
@@ -136,6 +141,7 @@ namespace PackageUrl
             if (Namespace != null)
             {
                 purl.Append(WebUtility.UrlEncode(Namespace));
+                purl.Replace(EncodedSlash, "/");
                 purl.Append('/');
             }
             if (Name != null)
@@ -238,7 +244,7 @@ namespace PackageUrl
                 int i;
                 for (i = 1; i < firstPartArray.Length - 2; ++i)
                 {
-                    @namespace += firstPartArray[i] + ',';
+                    @namespace += firstPartArray[i] + '/';
                 }
                 @namespace += firstPartArray[i];
 

--- a/tests/TestAssets/test-suite-data.json
+++ b/tests/TestAssets/test-suite-data.json
@@ -48,6 +48,18 @@
     "is_invalid": false
   },
   {
+    "description": "valid go purl with version, subpath, and multi-part namespace",
+    "purl": "pkg:GOLANG/github.com/gorilla/context@234fd47e07d1004f0aed9c#api/",
+    "canonical_purl": "pkg:golang/github.com/gorilla/context@234fd47e07d1004f0aed9c#api",
+    "type": "golang",
+    "namespace": "github.com/gorilla",
+    "name": "context",
+    "version": "234fd47e07d1004f0aed9c",
+    "qualifiers": null,
+    "subpath": "api",
+    "is_invalid": false
+  },
+  {
     "description": "bitbucket namespace and name should be lowercased",
     "purl": "pkg:bitbucket/birKenfeld/pyGments-main@244fd47e07d1014f0aed9c",
     "canonical_purl": "pkg:bitbucket/birkenfeld/pygments-main@244fd47e07d1014f0aed9c",


### PR DESCRIPTION
The Go package `pkg:golang/github.com/gorilla/context@234fd47e07d1004f0aed9c#api` would previously be `pkg:golang/github.com%2Cgorilla/context@234fd47e07d1004f0aed9c#api` as the namespace would be split and joined with `,` vs `/`.
Added a test for it as well.

For context, the packageurl-js implementation handles namespaces in this new way.