### PR TITLE
Update the parse logic to allow Maven package names to be case-sensitive

### DIFF
--- a/src/PackageUrl.cs
+++ b/src/PackageUrl.cs
@@ -276,7 +276,7 @@ namespace PackageUrl
             }
             return Type switch
             {
-                "nuget" or "cocoapods" or "cpan" or "vsm" or "cran" or "npm" => name,
+                "nuget" or "cocoapods" or "cpan" or "vsm" or "cran" or "npm" or "maven" => name,
                 "pypi" => name.Replace('_', '-').ToLower(),
                 _ => name.ToLower()
             };

--- a/tests/TestAssets/test-suite-data.json
+++ b/tests/TestAssets/test-suite-data.json
@@ -349,5 +349,17 @@
     "qualifiers": null,
     "subpath": null,
     "is_invalid": false
+  },
+  {
+    "description": "Maven names are case sensitive",
+    "purl": "pkg:maven/com.googlecode.javaewah/JavaEWAH@1.1.12",
+    "canonical_purl": "pkg:maven/com.googlecode.javaewah/JavaEWAH@1.1.12",
+    "type": "maven",
+    "namespace": "com.googlecode.javaewah",
+    "name": "JavaEWAH",
+    "version": "1.1.12",
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
   }
 ]


### PR DESCRIPTION
Package names for Maven can be case-sensitive, as per packages such as https://repo1.maven.org/maven2/com/googlecode/javaewah/JavaEWAH/.