### PR TITLE
Standardize namespace and name normalization to match Python library

### DIFF
--- a/src/PackageUrl.cs
+++ b/src/PackageUrl.cs
@@ -263,8 +263,8 @@ namespace PackageUrl
             }
             return Type switch
             {
-                "vsm" or "cran" => WebUtility.UrlDecode(@namespace),
-                _ => WebUtility.UrlDecode(@namespace.ToLower())
+                "bitbucket" or "github" or "pypi" or "gitlab" => WebUtility.UrlDecode(@namespace.ToLower()),
+                _ => WebUtility.UrlDecode(@namespace)
             };
         }
 
@@ -276,9 +276,9 @@ namespace PackageUrl
             }
             return Type switch
             {
-                "nuget" or "cocoapods" or "cpan" or "vsm" or "cran" or "npm" => name,
+                "bitbucket" or "github" or "gitlab" => name.ToLower(),
                 "pypi" => name.Replace('_', '-').ToLower(),
-                _ => name.ToLower()
+                _ => name
             };
         }
 

--- a/tests/TestAssets/test-suite-data.json
+++ b/tests/TestAssets/test-suite-data.json
@@ -349,5 +349,17 @@
     "qualifiers": null,
     "subpath": null,
     "is_invalid": false
+  },
+  {
+    "description": "Maven names are case sensitive",
+    "purl": "pkg:maven/com.googlecode.javaewah/JavaEWAH@1.1.12",
+    "canonical_purl": "pkg:maven/com.googlecode.javaewah/JavaEWAH@1.1.12",
+    "type": "maven",
+    "namespace": "com.googlecode.javaewah",
+    "name": "JavaEWAH",
+    "version": "1.1.12",
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
   }
 ]

--- a/tests/TestAssets/test-suite-data.json
+++ b/tests/TestAssets/test-suite-data.json
@@ -361,5 +361,17 @@
     "qualifiers": null,
     "subpath": null,
     "is_invalid": false
+  },
+  {
+    "description": "github namespace and name should be lowercased",
+    "purl": "pkg:github/Package-url/purl-Spec@244fd47e07d1004f0aed9c",
+    "canonical_purl": "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c",
+    "type": "github",
+    "namespace": "package-url",
+    "name": "purl-spec",
+    "version": "244fd47e07d1004f0aed9c",
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
   }
 ]


### PR DESCRIPTION
This change adjusts the normalization for namespace and names to only apply changes that are necessary to be compliant for the given package protocol.  This aligns with how the Python library implements normalization, and is done per the request in this pull request (https://github.com/package-url/packageurl-dotnet/pull/19#discussion_r1007339775).