### PR TITLE
Don't escape colons in qualifier values

### DIFF
--- a/src/PackageUrl.cs
+++ b/src/PackageUrl.cs
@@ -160,7 +160,7 @@ namespace PackageUrl
                 purl.Append("?");
                 foreach (var pair in Qualifiers)
                 {
-                    string encodedValue = WebUtility.UrlEncode(pair.Value).Replace(EncodedSlash, "/");
+                    string encodedValue = WebUtility.UrlEncode(pair.Value).Replace(EncodedSlash, "/").Replace(EncodedColon, ":");
                     purl.Append(pair.Key.ToLower());
                     purl.Append('=');
                     purl.Append(encodedValue);

--- a/tests/TestAssets/test-suite-data.json
+++ b/tests/TestAssets/test-suite-data.json
@@ -303,6 +303,20 @@
     "is_invalid": false
   },
   {
+    "description": "colons and slashes aren't escaped in qualifer values",
+    "purl": "pkg:cocoapods/MapsIndoors@3.24.0?repository_url=https://contoso.com",
+    "canonical_purl": "pkg:cocoapods/MapsIndoors@3.24.0?repository_url=https://contoso.com",
+    "type": "cocoapods",
+    "namespace": null,
+    "name": "MapsIndoors",
+    "version": "3.24.0",
+    "qualifiers": {
+      "repository_url": "https://contoso.com"
+    },
+    "subpath": null,
+    "is_invalid": false
+  },
+  {
     "description": "cocoapods names are case sensitive",
     "purl": "pkg:cocoapods/MapsIndoors@3.24.0",
     "canonical_purl": "pkg:cocoapods/MapsIndoors@3.24.0",


### PR DESCRIPTION
When adding a URL as a qualifier value, I was noticing that the URL's colons would be escaped. They should not be escaped.