### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,20 +32,25 @@ dotnet add <Path-to-Project-file> package packageurl-dotnet
 or in project file, add:
 
 ```xml
-<PackageReference Include="packageurl-dotnet" Version="1.0.0" />
+<PackageReference Include="packageurl-dotnet" Version="1.3.0" />
 ```
 
 Usage
 -------------------
 
+Import namespace:
+```c#
+import PackageUrl;
+```
+
 Creates a new PURL object from a string:
 ```c#
-PackageUrl purl = new PackageUrl(purlString);
+PackageURL purl = new PackageURL(purlString);
 ````
 
 Creates a new PURL object from purl parameters:
 ```c#
-PackageUrl purl = new PackageUrl(type, namespace, name, version, qualifiers, subpath);
+PackageURL purl = new PackageURL(type, namespace, name, version, qualifiers, subpath);
 ````
 
 License


### PR DESCRIPTION
The Namespace is defined as "PackageUrl" but the class is defined as "PackageURL". Updates usage instructions to match the correct casing.

* Fix capitalization of PackageURL class in Usage section. 
* Update Installation section to refer to latest version.