### PR TITLE
Rename PackageUrl class to PackageURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Or in your project file:
 Parse a PURL string:
 
 ```csharp
-var purl = new PackageUrl("pkg:nuget/Newtonsoft.Json@13.0.1");
+var purl = new PackageURL("pkg:nuget/Newtonsoft.Json@13.0.1");
 
 Console.WriteLine(purl.Type);      // nuget
 Console.WriteLine(purl.Name);      // Newtonsoft.Json
@@ -35,7 +35,7 @@ Console.WriteLine(purl.Version);   // 13.0.1
 Build one from parts:
 
 ```csharp
-var purl = new PackageUrl(
+var purl = new PackageURL(
     type: "maven",
     @namespace: "org.apache.commons",
     name: "commons-lang3",
@@ -50,7 +50,7 @@ Console.WriteLine(purl.ToString());
 There's also a two-argument shorthand if you only need type and name:
 
 ```csharp
-var purl = new PackageUrl("npm", "lodash");
+var purl = new PackageURL("npm", "lodash");
 ```
 
 ## Build from source

--- a/benchmarks/PackageUrlBenchmarks.cs
+++ b/benchmarks/PackageUrlBenchmarks.cs
@@ -18,7 +18,7 @@ public class PackageUrlBenchmarks
             "pkg:maven/org.apache/xmlgraphics-commons@1.5?classifier=sources&repository_url=repo.spring.io#src/main/java",
     };
 
-    private readonly Dictionary<string, PackageUrl> _parsed = new();
+    private readonly Dictionary<string, PackageURL> _parsed = new();
 
     [ParamsSource(nameof(PurlNames))]
     public string Purl { get; set; } = null!;
@@ -30,7 +30,7 @@ public class PackageUrlBenchmarks
     {
         foreach (var kvp in _purls)
         {
-            _parsed[kvp.Key] = new PackageUrl(kvp.Value);
+            _parsed[kvp.Key] = new PackageURL(kvp.Value);
         }
     }
 
@@ -38,7 +38,7 @@ public class PackageUrlBenchmarks
 
     [Benchmark(Baseline = true)]
     [BenchmarkCategory("Parse")]
-    public PackageUrl Parse() => new(_purls[Purl]);
+    public PackageURL Parse() => new(_purls[Purl]);
 
     // --- ToString ---
 

--- a/src/PackageUrl.cs
+++ b/src/PackageUrl.cs
@@ -40,7 +40,7 @@ namespace PackageUrl;
 /// See <see href="https://ecma-tc54.github.io/ECMA-427/">ECMA-427</see> for the full specification.
 /// </para>
 /// </summary>
-public sealed class PackageUrl : IEquatable<PackageUrl>
+public sealed class PackageURL : IEquatable<PackageURL>
 {
     private readonly int _hashCode;
 
@@ -82,27 +82,27 @@ public sealed class PackageUrl : IEquatable<PackageUrl>
     public string? Subpath { get; private set; }
 
     /// <summary>
-    /// Parses <paramref name="purl"/> into a new <see cref="PackageUrl"/>.
+    /// Parses <paramref name="purl"/> into a new <see cref="PackageURL"/>.
     /// </summary>
     /// <param name="purl">A valid Package URL string (e.g. <c>"pkg:npm/foobar@12.3.1"</c>).</param>
     /// <exception cref="MalformedPackageUrlException">Thrown if <paramref name="purl"/> is not a valid Package URL.</exception>
-    public PackageUrl(string purl)
+    public PackageURL(string purl)
     {
         Parse(purl);
         _hashCode = ComputeHashCode();
     }
 
     /// <summary>
-    /// Creates a <see cref="PackageUrl"/> with only the required type and name components.
+    /// Creates a <see cref="PackageURL"/> with only the required type and name components.
     /// </summary>
     /// <param name="type">The package type (e.g. nuget, npm, gem).</param>
     /// <param name="name">The package name.</param>
     /// <exception cref="MalformedPackageUrlException">Thrown if <paramref name="type"/> or <paramref name="name"/> is invalid.</exception>
-    public PackageUrl(string type, string name)
+    public PackageURL(string type, string name)
         : this(type, null, name, null, null, null) { }
 
     /// <summary>
-    /// Creates a <see cref="PackageUrl"/> from individual components.
+    /// Creates a <see cref="PackageURL"/> from individual components.
     /// </summary>
     /// <param name="type">The package type (e.g. nuget, npm, gem).</param>
     /// <param name="namespace">The type-specific namespace (e.g. Maven groupId, GitHub user), or <see langword="null"/>.</param>
@@ -111,7 +111,7 @@ public sealed class PackageUrl : IEquatable<PackageUrl>
     /// <param name="qualifiers">Qualifier key/value pairs, or <see langword="null"/>.</param>
     /// <param name="subpath">A path relative to the package root, or <see langword="null"/>.</param>
     /// <exception cref="MalformedPackageUrlException">Thrown if any component is invalid.</exception>
-    public PackageUrl(
+    public PackageURL(
         string type,
         string? @namespace,
         string name,
@@ -334,7 +334,7 @@ public sealed class PackageUrl : IEquatable<PackageUrl>
     }
 
     /// <inheritdoc />
-    public bool Equals(PackageUrl? other)
+    public bool Equals(PackageURL? other)
     {
         if (other is null)
         {
@@ -356,7 +356,7 @@ public sealed class PackageUrl : IEquatable<PackageUrl>
     }
 
     /// <inheritdoc />
-    public override bool Equals(object? obj) => Equals(obj as PackageUrl);
+    public override bool Equals(object? obj) => Equals(obj as PackageURL);
 
     /// <inheritdoc />
     public override int GetHashCode() => _hashCode;
@@ -383,10 +383,10 @@ public sealed class PackageUrl : IEquatable<PackageUrl>
         }
     }
 
-    public static bool operator ==(PackageUrl? left, PackageUrl? right) =>
+    public static bool operator ==(PackageURL? left, PackageURL? right) =>
         left is null ? right is null : left.Equals(right);
 
-    public static bool operator !=(PackageUrl? left, PackageUrl? right) => !(left == right);
+    public static bool operator !=(PackageURL? left, PackageURL? right) => !(left == right);
 
     private static bool QualifiersEqual(
         SortedDictionary<string, string>? a,

--- a/tests/PackageUrlSpecificationTests.cs
+++ b/tests/PackageUrlSpecificationTests.cs
@@ -37,11 +37,11 @@ public class PackageUrlSpecificationTests
     {
         if (data.ExpectedFailure)
         {
-            Assert.Throws<MalformedPackageUrlException>(() => new PackageUrl(data.InputPurl!));
+            Assert.Throws<MalformedPackageUrlException>(() => new PackageURL(data.InputPurl!));
             return;
         }
 
-        PackageUrl purl = new(data.InputPurl!);
+        PackageURL purl = new(data.InputPurl!);
         var expected = data.ExpectedComponents!;
 
         Assert.Equal("pkg", purl.Scheme);
@@ -70,7 +70,7 @@ public class PackageUrlSpecificationTests
         if (data.ExpectedFailure)
         {
             Assert.Throws<MalformedPackageUrlException>(() =>
-                new PackageUrl(
+                new PackageURL(
                     input.Type!,
                     input.Namespace,
                     input.Name!,
@@ -82,7 +82,7 @@ public class PackageUrlSpecificationTests
             return;
         }
 
-        PackageUrl purl = new(
+        PackageURL purl = new(
             input.Type!,
             input.Namespace,
             input.Name!,
@@ -100,11 +100,11 @@ public class PackageUrlSpecificationTests
     {
         if (data.ExpectedFailure)
         {
-            Assert.Throws<MalformedPackageUrlException>(() => new PackageUrl(data.InputPurl!));
+            Assert.Throws<MalformedPackageUrlException>(() => new PackageURL(data.InputPurl!));
             return;
         }
 
-        PackageUrl purl = new(data.InputPurl!);
+        PackageURL purl = new(data.InputPurl!);
         Assert.Equal(data.ExpectedPurl, purl.ToString());
     }
 }

--- a/tests/PackageUrlTests.cs
+++ b/tests/PackageUrlTests.cs
@@ -32,7 +32,7 @@ public class PackageUrlTests
     [InlineData("pkg:some,type/name")]
     public void TestTypeWithInvalidCharactersThrows(string purl)
     {
-        Assert.Throws<MalformedPackageUrlException>(() => new PackageUrl(purl));
+        Assert.Throws<MalformedPackageUrlException>(() => new PackageURL(purl));
     }
 
     [Theory]
@@ -40,7 +40,7 @@ public class PackageUrlTests
     [InlineData("pkg:valid.type/name")]
     public void TestTypeWithValidCharactersParses(string purl)
     {
-        var parsed = new PackageUrl(purl);
+        var parsed = new PackageURL(purl);
         Assert.NotNull(parsed.Type);
     }
 
@@ -51,13 +51,13 @@ public class PackageUrlTests
     [InlineData("pkg:npm/foo@1.0?_key=value")]
     public void TestInvalidQualifierKeyThrows(string purl)
     {
-        Assert.Throws<MalformedPackageUrlException>(() => new PackageUrl(purl));
+        Assert.Throws<MalformedPackageUrlException>(() => new PackageURL(purl));
     }
 
     [Fact]
     public void TestQualifierKeysAreLowercased()
     {
-        var purl = new PackageUrl("pkg:npm/foo@1.0?Arch=i386");
+        var purl = new PackageURL("pkg:npm/foo@1.0?Arch=i386");
         Assert.True(purl.Qualifiers!.ContainsKey("arch"));
         Assert.False(purl.Qualifiers!.ContainsKey("Arch"));
     }
@@ -65,14 +65,14 @@ public class PackageUrlTests
     [Fact]
     public void TestQualifierValueContainingEquals()
     {
-        var purl = new PackageUrl("pkg:npm/foo@1.0?key=val%3Due");
+        var purl = new PackageURL("pkg:npm/foo@1.0?key=val%3Due");
         Assert.Equal("val=ue", purl.Qualifiers!["key"]);
     }
 
     [Fact]
     public void TestEmptyQualifierValueIsDiscarded()
     {
-        var purl = new PackageUrl("pkg:npm/foo@1.0?empty=&arch=i386");
+        var purl = new PackageURL("pkg:npm/foo@1.0?empty=&arch=i386");
         Assert.False(purl.Qualifiers!.ContainsKey("empty"));
         Assert.Equal("i386", purl.Qualifiers!["arch"]);
     }
@@ -81,7 +81,7 @@ public class PackageUrlTests
     public void TestDuplicateQualifierKeyThrows()
     {
         Assert.Throws<MalformedPackageUrlException>(() =>
-            new PackageUrl("pkg:npm/foo@1.0?arch=i386&arch=amd64")
+            new PackageURL("pkg:npm/foo@1.0?arch=i386&arch=amd64")
         );
     }
 
@@ -93,7 +93,7 @@ public class PackageUrlTests
     public void TestSubpathWithDotSegmentsThrows(string subpath)
     {
         Assert.Throws<MalformedPackageUrlException>(() =>
-            new PackageUrl("npm", null, "foo", "1.0", null, subpath)
+            new PackageURL("npm", null, "foo", "1.0", null, subpath)
         );
     }
 
@@ -103,7 +103,7 @@ public class PackageUrlTests
     [InlineData("///path///file///", "path/file")]
     public void TestSubpathEmptySegmentsAreNormalized(string subpath, string expected)
     {
-        var purl = new PackageUrl("npm", null, "foo", "1.0", null, subpath);
+        var purl = new PackageURL("npm", null, "foo", "1.0", null, subpath);
         Assert.Equal(expected, purl.Subpath);
     }
 
@@ -112,7 +112,7 @@ public class PackageUrlTests
     public void TestNamespaceWithEmptySegmentThrows(string ns)
     {
         Assert.Throws<MalformedPackageUrlException>(() =>
-            new PackageUrl("npm", ns, "foo", "1.0", null, null)
+            new PackageURL("npm", ns, "foo", "1.0", null, null)
         );
     }
 
@@ -121,7 +121,7 @@ public class PackageUrlTests
     [InlineData("org/pkg/", "org/pkg")]
     public void TestNamespaceLeadingTrailingSlashesAreStripped(string ns, string expected)
     {
-        var purl = new PackageUrl("npm", ns, "foo", "1.0", null, null);
+        var purl = new PackageURL("npm", ns, "foo", "1.0", null, null);
         Assert.Equal(expected, purl.Namespace);
     }
 
@@ -129,7 +129,7 @@ public class PackageUrlTests
     public void TestEmptyNameThrows()
     {
         Assert.Throws<MalformedPackageUrlException>(() =>
-            new PackageUrl("npm", null, "", "1.0", null, null)
+            new PackageURL("npm", null, "", "1.0", null, null)
         );
     }
 }


### PR DESCRIPTION
Reverts the casing from PR #70 so the type no longer collides with the namespace. Consumers write `using PackageUrl;` and reference `PackageURL` without ambiguity.

Fixes #98